### PR TITLE
Fix Elm keywords list

### DIFF
--- a/gedit/elm.lang
+++ b/gedit/elm.lang
@@ -126,16 +126,28 @@
     </context>
 
     <context id="keyword" style-ref="keyword">
+      <keyword>alias</keyword>
+      <keyword>as</keyword>
       <keyword>case</keyword>
-      <keyword>type</keyword>
-      <keyword>type alias</keyword>
+      <keyword>command</keyword>
+      <keyword>effect</keyword>
       <keyword>else</keyword>
+      <keyword>exposing</keyword>
       <keyword>if</keyword>
       <keyword>import</keyword>
       <keyword>in</keyword>
+      <keyword>infix</keyword>
+      <keyword>left</keyword>
       <keyword>let</keyword>
       <keyword>module</keyword>
+      <keyword>non</keyword>
+      <keyword>of</keyword>
+      <keyword>port</keyword>
+      <keyword>right</keyword>
+      <keyword>subscription</keyword>
       <keyword>then</keyword>
+      <keyword>type</keyword>
+      <keyword>where</keyword>
     </context>
 
     <context id="body">


### PR DESCRIPTION
Changed haskell keyword list to Elm one using the compiler source:

https://github.com/elm/compiler/blob/38670361cd4b9f9f09621f3f5a7dbe07ebde7bf2/compiler/src/Parse/Keyword.hs#L4